### PR TITLE
Add viewport meta tag.

### DIFF
--- a/_layouts/siesta-nav.html
+++ b/_layouts/siesta-nav.html
@@ -8,6 +8,7 @@
     <link rel="shortcut icon" href='{{ "favicon.ico" | relative_url }}' >
     <link rel="canonical" href="{{ site.canonical_baseurl }}{{ page.url | replace:'index.html',''}}">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <script type="text/javascript">
 


### PR DESCRIPTION
Google Search Console reports this as a Mobile Usability error.

For more information on the viewport tag, see, e.g.,
https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag .