### PR TITLE
Reorganization of the landing page.

### DIFF
--- a/About/overview.html
+++ b/About/overview.html
@@ -26,6 +26,13 @@ the method
   2745 (2002))</a> has received more than 8000 citations so far.
 </p>
 
+<p>
+  For an overview of recent developments, and sample
+  applications of SIESTA,
+  see <a href="https://doi.org/10.1063/5.0005077">J. Chem. Phys. 152,
+     204108 (2020)</a>.
+</p>
+
 SIESTA's main characteristics are:
 
 <ul>
@@ -70,4 +77,10 @@ ballistic electron transport is taking place. Using TranSIESTA one can
 compute electronic transport properties, such as the zero-bias
 conductance and the I-V characteristic, of a nanoscale system in
 contact with two electrodes at different electrochemical potentials.
+
+
+<p>
+  SIESTA is one of the flagship codes of the <a href="https://www.max-centre.eu">MaX Center of Excellence</a>.
+</p>
+
 

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,13 +1,13 @@
     <nav>
       <ul>
-	<li><a href="{{ site.baseurl }}/">Home</a></li>
-	<li><a href="{{ site.baseurl }}/About/overview.html">About</a></li>
-        <li><a href="{{ site.baseurl }}/CodeAccess/index.html">Code</a></li>
+	<li><a href="{{ site.baseurl }}/index.html">Home</a></li>
+	<li><a href="{{ site.baseurl }}/CodeAccess/index.html">Code</a></li>
 	<li><a href="{{ site.baseurl }}/Documentation/index.html">Documentation</a></li>
-        <li><a href="{{ site.baseurl }}/Pseudopotentials/index.html">Pseudopotentials</a>
-	<li><a href="{{ site.baseurl }}/About/team.html">The Team</a></li>
-	<li><a href="{{ site.baseurl }}/blog">News</a></li>
-	<li><a href="{{ site.baseurl }}/events">Events</a></li>
+    <li><a href="{{ site.baseurl }}/Pseudopotentials/index.html">Pseudopotentials</a>
 	<li><a href="{{ site.baseurl }}/External/support.html">Support</a></li>
+<!--	<li><a href="{{ site.baseurl }}/blog/index.html">News</a></li> -->
+	<li><a href="{{ site.baseurl }}/events/index.html">Events</a></li>
+	<li><a href="{{ site.baseurl }}/About/overview.html">About</a></li>
+	<li><a href="{{ site.baseurl }}/About/team.html">The Team</a></li>
       </ul>
     </nav>

--- a/index.html
+++ b/index.html
@@ -2,40 +2,30 @@
 layout: siesta-nav
 title: Siesta Web page
 ---
-<p>
-SIESTA is both a method and its computer program implementation, to
-perform efficient electronic structure calculations and ab initio
-molecular dynamics simulations of molecules and solids.  SIESTA's
-efficiency stems from the use of a basis set of strictly-localized
-atomic orbitals. A very important feature of the code is
-that its accuracy and cost can be tuned in a wide range, from quick
-exploratory calculations to highly accurate simulations matching the
-quality of other approaches, such as plane-wave methods.
-</p>
-<p>
-The possibility of treating large systems with some first-principles
-electronic-structure methods has opened up new opportunities in many
-disciplines. The SIESTA program is open source and has become quite
-popular, being increasingly used by researchers in
-geosciences, biology, and engineering (apart from those in its natural
-habitat of materials physics and chemistry). Currently there are
-several thousand users all over the world, and the paper describing
-the method
-<a href="http://iopscience.iop.org/article/10.1088/0953-8984/14/11/302/meta">(J. Phys. Cond. Matt. 14,
-  2745 (2002))</a> has received more than 8000 citations so far.
-</p>
+<div align="center">
+  <img src=https://siesta-project.org/siesta/SIESTA-logo-233x125.png>
+<br>
+<br>
+<b><a href="{{ site.baseurl }}/CodeAccess/index.html"> Get the Code!</a></b>
+<br>
+<br>
+<b><a href=https://docs.siesta-project.org/projects/siesta/en/latest/installation/quick-install.html> SIESTA Installation</a></b>
+<br>
+<br>
+<b><a href=https://docs.siesta-project.org/projects/siesta/en/latest/tutorials/index.html> Tutorials</a></b>
+<br>
+<br>
+<b><a href=https://docs.siesta-project.org/projects/siesta> General Documentation</a></b>
+<br>
+<br>
+<b><a href="{{ site.baseurl }}/External/support.html">Support</a></b>
+<br>
+<br>
+<b><a href=https://gitlab.com/siesta-project/siesta> SIESTA on GitLab</a></b>
+
+</div>
 
 <p>
- For an overview of recent developments, and sample
- applications of SIESTA,
- see <a href="https://doi.org/10.1063/5.0005077">J. Chem. Phys. 152,
-    204108 (2020)</a>.
- </p>
-
-<p>
-SIESTA is one of the flagship codes of the <a href="https://www.max-centre.eu">MaX Center of Excellence</a>.
-</p>
-<p>
-&copy; The SIESTA group (2020)
+&copy; The SIESTA group (2024)
 </p>
 


### PR DESCRIPTION
The landing page had a lot of text that served little purpose, as it was an (almost) duplicate of the about page.

Now we just keep a collection of links until we get a slideshow of images to put in here.

Also, reordered the navigation bar in a more intuitive way, and disabled the access to the "news" section from the time being.